### PR TITLE
Fix the unclear prompts

### DIFF
--- a/src/main/java/org/fisco/bcos/sdk/contract/Contract.java
+++ b/src/main/java/org/fisco/bcos/sdk/contract/Contract.java
@@ -37,6 +37,7 @@ import org.fisco.bcos.sdk.crypto.CryptoInterface;
 import org.fisco.bcos.sdk.eventsub.EventCallback;
 import org.fisco.bcos.sdk.eventsub.EventLogParams;
 import org.fisco.bcos.sdk.eventsub.EventSubscribe;
+import org.fisco.bcos.sdk.model.RetCode;
 import org.fisco.bcos.sdk.model.TransactionReceipt;
 import org.fisco.bcos.sdk.transaction.codec.decode.ReceiptParser;
 import org.fisco.bcos.sdk.transaction.manager.TransactionManager;
@@ -140,9 +141,10 @@ public class Contract {
 
         String contractAddress = transactionReceipt.getContractAddress();
         if (contractAddress == null) {
+            // parse the receipt
+            RetCode retCode = ReceiptParser.parseTransactionReceipt(transactionReceipt);
             throw new ContractException(
-                    "Deploy contract failed: empty contract address returned, transactionReceipt: "
-                            + transactionReceipt.toString());
+                    "Deploy contract failed, error message: " + retCode.getMessage());
         }
         contract.setContractAddress(contractAddress);
         contract.setDeployReceipt(transactionReceipt);

--- a/src/main/java/org/fisco/bcos/sdk/crypto/signature/SM2Signature.java
+++ b/src/main/java/org/fisco/bcos/sdk/crypto/signature/SM2Signature.java
@@ -33,7 +33,9 @@ public class SM2Signature implements Signature {
 
     @Override
     public String signWithStringSignature(final String message, final CryptoKeyPair keyPair) {
-        CryptoResult signatureResult = NativeInterface.sm2Sign(keyPair.getHexPrivateKey(), message);
+        CryptoResult signatureResult =
+                NativeInterface.sm2SignWithPub(
+                        keyPair.getHexPrivateKey(), keyPair.getHexPublicKey(), message);
         if (signatureResult.wedprErrorMessage != null
                 && !signatureResult.wedprErrorMessage.isEmpty()) {
             throw new SignatureException(

--- a/src/main/java/org/fisco/bcos/sdk/network/NetworkImp.java
+++ b/src/main/java/org/fisco/bcos/sdk/network/NetworkImp.java
@@ -179,7 +179,12 @@ public class NetworkImp implements Network {
             configOption.reloadConfig(CryptoInterface.SM_TYPE);
             result = checkCertExistence(true);
             if (!result.isCheckPassed()) {
-                throw new NetworkException("Certificate not exist:" + result.getErrorMessage());
+                if (tryEcdsaConnect) {
+                    throw new NetworkException("Certificate not exist:" + result.getErrorMessage());
+                } else {
+                    throw new NetworkException(
+                            "Not providing all the certificates to connect to the node! Please provide the certificates to connect with the block-chain.");
+                }
             }
             if (tryEcdsaConnect) {
                 // create a new connectionManager to connect the node with the SM sslContext


### PR DESCRIPTION
1. Fix the unclear prompt when the certificate does not exist and the deployment contract is abnormal

2. gm sign performance optimize