### PR TITLE
bugfix-#580,sol2java.sh 生成java代码编译报错, 修复合约参数构造循环i错误的没有递增，

### DIFF
--- a/sdk-codegen/src/main/java/org/fisco/bcos/sdk/codegen/SolidityContractWrapper.java
+++ b/sdk-codegen/src/main/java/org/fisco/bcos/sdk/codegen/SolidityContractWrapper.java
@@ -482,8 +482,7 @@ public class SolidityContractWrapper {
             MethodSpec.Builder methodBuilder, List<ABIDefinition.NamedType> namedTypes) {
         List<ParameterSpec> inputParameterTypes = buildParameterTypes(namedTypes);
         List<ParameterSpec> nativeInputParameterTypes = new ArrayList<>(inputParameterTypes.size());
-        int i = 0;
-        for (ParameterSpec parameterSpec : inputParameterTypes) {
+        for (int i = 0; i < inputParameterTypes.size(); i++) {
             final TypeName typeName;
             if (namedTypes.get(i).getType().equals("tuple")) {
                 typeName = structClassNameMap.get(namedTypes.get(i).structIdentifier());
@@ -495,7 +494,7 @@ public class SolidityContractWrapper {
             }
 
             nativeInputParameterTypes.add(
-                    ParameterSpec.builder(typeName, parameterSpec.name).build());
+                    ParameterSpec.builder(typeName, inputParameterTypes.get(i).name).build());
         }
         methodBuilder.addParameters(nativeInputParameterTypes);
         return Collection.join(


### PR DESCRIPTION
在SDK code gen时 通过sol合约参数 构造java 函数参数表时 错误的在循环中没有递增i. 