### PR TITLE
sdk 支持域名方式 兼容k8s svcname

### DIFF
--- a/sdk-amop/src/main/java/org/fisco/bcos/sdk/amop/topic/AmopMsgHandler.java
+++ b/sdk-amop/src/main/java/org/fisco/bcos/sdk/amop/topic/AmopMsgHandler.java
@@ -21,11 +21,8 @@ import static org.fisco.bcos.sdk.amop.topic.TopicManager.verifyChannelPrefix;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.SocketChannel;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.net.InetSocketAddress;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import org.fisco.bcos.sdk.amop.Amop;
 import org.fisco.bcos.sdk.amop.AmopCallback;
@@ -34,11 +31,7 @@ import org.fisco.bcos.sdk.channel.ResponseCallback;
 import org.fisco.bcos.sdk.channel.model.Options;
 import org.fisco.bcos.sdk.crypto.CryptoSuite;
 import org.fisco.bcos.sdk.crypto.keypair.CryptoKeyPair;
-import org.fisco.bcos.sdk.model.AmopMsg;
-import org.fisco.bcos.sdk.model.CryptoType;
-import org.fisco.bcos.sdk.model.Message;
-import org.fisco.bcos.sdk.model.MsgType;
-import org.fisco.bcos.sdk.model.Response;
+import org.fisco.bcos.sdk.model.*;
 import org.fisco.bcos.sdk.network.MsgHandler;
 import org.fisco.bcos.sdk.utils.Hex;
 import org.fisco.bcos.sdk.utils.ObjectMapperFactory;
@@ -70,8 +63,9 @@ public class AmopMsgHandler implements MsgHandler {
             return;
         }
 
-        String host = ((SocketChannel) ctx.channel()).remoteAddress().getAddress().getHostAddress();
-        Integer port = ((SocketChannel) ctx.channel()).remoteAddress().getPort();
+        InetSocketAddress inetSocketAddress = ((SocketChannel) ctx.channel()).remoteAddress();
+        String host = inetSocketAddress.getAddress().getHostName();
+        Integer port = inetSocketAddress.getPort();
         String ipAndPort = host + ":" + port;
         logger.info("Node connected, update topics to node. node:" + ipAndPort);
         try {

--- a/sdk-core/src/main/java/org/fisco/bcos/sdk/channel/ChannelVersionNegotiation.java
+++ b/sdk-core/src/main/java/org/fisco/bcos/sdk/channel/ChannelVersionNegotiation.java
@@ -3,6 +3,7 @@ package org.fisco.bcos.sdk.channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.AttributeKey;
+import java.net.InetSocketAddress;
 import org.fisco.bcos.sdk.channel.model.ChannelProtocol;
 import org.fisco.bcos.sdk.channel.model.EnumChannelProtocolVersion;
 import org.fisco.bcos.sdk.channel.model.EnumSocketChannelAttributeKey;
@@ -53,9 +54,9 @@ public class ChannelVersionNegotiation {
 
     public static String getPeerHost(ChannelHandlerContext ctx) {
 
-        SocketChannel socketChannel = (SocketChannel) ctx.channel();
-        String hostAddress = socketChannel.remoteAddress().getAddress().getHostAddress();
-        int port = socketChannel.remoteAddress().getPort();
+        InetSocketAddress inetSocketAddress = ((SocketChannel) ctx.channel()).remoteAddress();
+        String hostAddress = inetSocketAddress.getAddress().getHostName();
+        Integer port = inetSocketAddress.getPort();
         return hostAddress + ":" + port;
     }
 

--- a/sdk-core/src/main/java/org/fisco/bcos/sdk/config/model/NetworkConfig.java
+++ b/sdk-core/src/main/java/org/fisco/bcos/sdk/config/model/NetworkConfig.java
@@ -45,7 +45,7 @@ public class NetworkConfig {
                         " Invalid configuration, the peer value should in IP:Port format(eg: 127.0.0.1:1111), value: "
                                 + peer);
             }
-            String IP = peer.substring(0, index);
+            String IP = Host.getIpFromHost(peer.substring(0, index));
             String port = peer.substring(index + 1);
 
             if (!(NetUtil.isValidIpV4Address(IP) || NetUtil.isValidIpV6Address(IP))) {

--- a/sdk-core/src/main/java/org/fisco/bcos/sdk/network/ChannelHandler.java
+++ b/sdk-core/src/main/java/org/fisco/bcos/sdk/network/ChannelHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.timeout.IdleStateEvent;
+import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import org.fisco.bcos.sdk.model.Message;
@@ -47,8 +48,9 @@ public class ChannelHandler extends SimpleChannelInboundHandler<Message> {
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        String host = ((SocketChannel) ctx.channel()).remoteAddress().getAddress().getHostAddress();
-        Integer port = ((SocketChannel) ctx.channel()).remoteAddress().getPort();
+        InetSocketAddress inetSocketAddress = ((SocketChannel) ctx.channel()).remoteAddress();
+        String host = inetSocketAddress.getAddress().getHostName();
+        Integer port = inetSocketAddress.getPort();
         if (evt instanceof IdleStateEvent) {
             final IdleStateEvent e = (IdleStateEvent) evt;
             switch (e.state()) {
@@ -120,9 +122,9 @@ public class ChannelHandler extends SimpleChannelInboundHandler<Message> {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         try {
             // lost the connection, get ip info
-            String host =
-                    ((SocketChannel) ctx.channel()).remoteAddress().getAddress().getHostAddress();
-            Integer port = ((SocketChannel) ctx.channel()).remoteAddress().getPort();
+            InetSocketAddress inetSocketAddress = ((SocketChannel) ctx.channel()).remoteAddress();
+            String host = inetSocketAddress.getAddress().getHostName();
+            Integer port = inetSocketAddress.getPort();
 
             logger.debug(
                     " channelInactive, disconnect "

--- a/sdk-core/src/main/java/org/fisco/bcos/sdk/utils/Host.java
+++ b/sdk-core/src/main/java/org/fisco/bcos/sdk/utils/Host.java
@@ -15,6 +15,8 @@
 
 package org.fisco.bcos.sdk.utils;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -66,5 +68,19 @@ public class Host {
         int index = IPAndPort.lastIndexOf(':');
         String port = IPAndPort.substring(index + 1);
         return port;
+    }
+
+    /**
+     * Get ip from HostName
+     *
+     * @param hostName the hostName
+     * @return String of hostName.
+     */
+    public static String getIpFromHost(String hostName) {
+        try {
+            return InetAddress.getByName(hostName).getHostAddress();
+        } catch (UnknownHostException e) {
+            return hostName;
+        }
     }
 }


### PR DESCRIPTION
((SocketChannel) ctx.channel()).remoteAddress().getAddress().getHostName() 如果是域名方式返回域名，如果是ip，则返回ip地址
1.ChannelHandler.userEventTriggered()，修改这里获取hostname
2.AddressUtils添加一个方法 getIpByHost
3.NetworkConfig.checkPeers() 判断ip的时候，把hostname转成ip
String IP = AddressUtils.getIpByHost(peer.substring(0, index));
4.AmopMsgHandler.onConnect(); ChannelVersionNegotiation.getPeerHost() 修改为获取hostmae