### PR TITLE
bugfix,sol2java.sh struct合约生产java类支持各种复杂场景，数字、嵌套等。

### DIFF
--- a/sdk-abi/src/main/java/org/fisco/bcos/sdk/abi/TypeDecoder.java
+++ b/sdk-abi/src/main/java/org/fisco/bcos/sdk/abi/TypeDecoder.java
@@ -435,9 +435,10 @@ public class TypeDecoder {
             int dynamicParametersToProcess =
                     getDynamicStructDynamicParametersCount(constructor.getParameterTypes());
             for (int i = 0; i < length; ++i) {
+                java.lang.reflect.Type genericParameterType =
+                        constructor.getGenericParameterTypes()[i];
                 TypeReference<T> typeReferenceElement =
-                        TypeReference.create(
-                                Utils.getClassType(constructor.getGenericParameterTypes()[i]));
+                        TypeReference.create(Utils.getClassType(genericParameterType));
                 if (isDynamic(typeReferenceElement.getClassType())) {
                     final boolean isLastParameterInStruct =
                             dynamicParametersProcessed == (dynamicParametersToProcess - 1);
@@ -453,7 +454,8 @@ public class TypeDecoder {
                                     input,
                                     parameterOffsets.get(dynamicParametersProcessed),
                                     parameterLength,
-                                    typeReferenceElement));
+                                    typeReferenceElement,
+                                    genericParameterType));
                     dynamicParametersProcessed++;
                 }
             }
@@ -571,7 +573,8 @@ public class TypeDecoder {
             final String input,
             final int parameterOffset,
             final int parameterLength,
-            TypeReference<T> typeReference)
+            TypeReference<T> typeReference,
+            java.lang.reflect.Type genericParameterType)
             throws ClassNotFoundException {
         final String dynamicElementData =
                 input.substring(parameterOffset, parameterOffset + parameterLength);
@@ -580,7 +583,7 @@ public class TypeDecoder {
         if (DynamicStruct.class.isAssignableFrom(typeReference.getClassType())) {
             value = decodeDynamicStruct(dynamicElementData, 0, typeReference);
         } else if (DynamicArray.class.isAssignableFrom(typeReference.getClassType())) {
-            value = decodeDynamicArray(dynamicElementData, 0, typeReference.getType());
+            value = decodeDynamicArray(dynamicElementData, 0, genericParameterType);
         } else {
             value = decode(dynamicElementData, 0, typeReference.getClassType());
         }

--- a/sdk-abi/src/main/java/org/fisco/bcos/sdk/abi/datatypes/Array.java
+++ b/sdk-abi/src/main/java/org/fisco/bcos/sdk/abi/datatypes/Array.java
@@ -1,5 +1,6 @@
 package org.fisco.bcos.sdk.abi.datatypes;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +40,15 @@ public abstract class Array<T extends Type> implements Type<List<T>> {
     @Override
     public List<T> getValue() {
         return value;
+    }
+
+    public List getNativeValue() {
+        List list = new ArrayList(value.size());
+        for (T t : value) {
+            list.add(t.getValue());
+        }
+
+        return list;
     }
 
     @Override


### PR DESCRIPTION
修复如下场景：
* solidity 支持struct中有原子类型数组
* solidity 支持struct中的有struct数组
* solidity 支持参数和返回值都有多数组的复杂类型