### PR TITLE
添加CommitteeManager.java合约的引用注释

### DIFF
--- a/src/main/java/org/fisco/bcos/sdk/v3/contract/auth/contracts/CommitteeManager.java
+++ b/src/main/java/org/fisco/bcos/sdk/v3/contract/auth/contracts/CommitteeManager.java
@@ -28,6 +28,7 @@ import org.fisco.bcos.sdk.v3.model.callback.TransactionCallback;
 import org.fisco.bcos.sdk.v3.transaction.model.exception.ContractException;
 import org.fisco.bcos.sdk.v3.utils.StringUtils;
 
+// Compiled from https://github.com/FISCO-BCOS/bcos-auth/blob/main/CommitteeManager.sol
 @SuppressWarnings("unchecked")
 public class CommitteeManager extends Contract {
     public static final String[] ABI_ARRAY = {


### PR DESCRIPTION
添加所编译合约代码的注释，便于查询和维护代码