### PR TITLE
<CI>(workflow): restore Codecov unit-test coverage upload

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -53,3 +53,41 @@ jobs:
       - name: run integration testing
         if: runner.os != 'Windows'
         run: /bin/bash .ci/ci_check.sh
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+      - uses: actions/cache@v3
+        id: deps_cache
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: coverage-${{ github.base_ref }}-${{ hashFiles('.github/workflows/workflow.yml') }}
+          restore-keys: |
+            coverage-${{ github.base_ref }}-
+            coverage-
+      - name: install Ubuntu dependencies
+        run: |
+          sudo apt update && sudo apt install -y git curl libssl-dev build-essential
+      - name: Set up JDK 1.8.0.382
+        uses: actions/setup-java@v3
+        with:
+            distribution: 'zulu'
+            java-version: '8.0.382'
+      - name: run unit tests with coverage
+        run: /bin/bash gradlew test jacocoTestReport
+      - name: upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./build/reports/jacoco/test/jacocoTestReport.xml
+          flags: unittest
+          fail_ci_if_error: false
+          verbose: true


### PR DESCRIPTION
## What

Restores Codecov coverage reports on pull requests.

## Why

Codecov stopped reporting coverage after commit `9837e924` (#941), which deleted the `build-centos` job. That job carried the **only** coverage-upload step in the workflow:

```yaml
- name: upload unittest coverage
  run: curl -LO https://codecov.io/bash && /bin/bash ./bash
```

Since then the remaining `build` matrix job runs tests but never uploads a JaCoCo report, so Codecov has no data and posts no coverage report/comment on any PR. `.codecov.yml` and the `jacoco` plugin (`jacocoTestReport`, `xml.enabled = true`) are still configured — only the upload was missing.

## Change

Adds a dedicated `coverage` job that:

- runs the unit tests and generates the JaCoCo XML report via `gradlew test jacocoTestReport`;
- uploads `build/reports/jacoco/test/jacocoTestReport.xml` to Codecov with the existing `CODECOV_TOKEN` secret (`codecov/codecov-action@v4`).

Notes:

- **Unit-test scope is intentional** and matches `.codecov.yml`, which already `ignore`s `src/integration-test/**` and `src/integration-wasm-test/**`. So this needs no live FISCO BCOS node and is fast/deterministic.
- The job is `continue-on-error: true`, so it **never blocks** a PR.
- No untrusted input is used in any `run:` step (only the `CODECOV_TOKEN` secret), so there is no workflow-injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
