### PR TITLE
<CI>(workflow): Codecov BASE-on-push + fix macOS openssl / bump Ubuntu runner

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,9 @@
 name: Java-SDK GitHub Actions
 on:
+  push:
+    branches:
+      - master
+      - 'release-*'
   pull_request:
   release:
     types: [ published, created, edited ]
@@ -10,6 +14,10 @@ env:
 jobs:
   build:
     name: build
+    # Heavy integration build runs on PRs and releases only; pushes to the main
+    # branches run just the lightweight 'coverage' job below (to upload a Codecov
+    # BASE report so PRs can show a coverage delta).
+    if: github.event_name != 'push'
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, windows-2025, macos-latest ]
+        os: [ ubuntu-latest, windows-2025, macos-latest ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -49,7 +49,7 @@ jobs:
       - name: install macOS dependencies
         if: runner.os == 'macOS'
         run: |
-          brew install openssl@1.1 ccache
+          brew install openssl@3 ccache
       - name: Set up JDK 1.8.0.382
         uses: actions/setup-java@v3
         with:
@@ -64,7 +64,7 @@ jobs:
 
   coverage:
     name: coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What

CI/workflow maintenance, two parts:

### 1. Codecov BASE report on push
Codecov warned `Please upload report for BASE (...)` and left the `+/-` column empty on PRs. Root cause: the workflow only ran on `pull_request`/`release`, so merges (which are pushes) never uploaded coverage for the base commit. Add a `push` trigger for `master`/`release-*` and gate the heavy integration `build` job to non-push events, so a push runs only the lightweight `coverage` job and produces a BASE report. After this lands, future PRs show a proper coverage delta.

### 2. Fix broken runners
- **macOS** hard-failed at dependency install: Homebrew removed the `openssl@1.1` formula, so `brew install openssl@1.1` exits 1 (`No available formula with the name "openssl@1.1"`). Switch to `openssl@3` — the SDK native works on OpenSSL 3.x (the Ubuntu job already runs the full integration suite with libssl 3.x).
- **Ubuntu** runner bumped `ubuntu-22.04` → `ubuntu-latest` (build matrix + coverage job).

> Note: the remaining Ubuntu integration failures are **pre-existing flaky tests** (node/chain state, e.g. `-4008` / `Call address error` / EIP-1559 decode), unrelated to the runner version. The `build` job is `continue-on-error`, so it does not block merge.

No source code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
